### PR TITLE
Remove version symlinks

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: 5acb90acd82b10971717aca6c17874390762ecdaa3a8e4db04984ea1d4a2af9b
   patches:
     - python_orocos_kdl.patch
+    - remove_version_symlinks.patch 
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: orocos-kdl

--- a/recipe/remove_version_symlinks.patch
+++ b/recipe/remove_version_symlinks.patch
@@ -1,0 +1,13 @@
+diff --git a/orocos_kdl/src/CMakeLists.txt b/orocos_kdl/src/CMakeLists.txt
+index ca63079c..5b8f81c2 100644
+--- a/orocos_kdl/src/CMakeLists.txt
++++ b/orocos_kdl/src/CMakeLists.txt
+@@ -58,8 +58,6 @@ ENDIF()
+ ADD_LIBRARY(orocos-kdl ${LIB_TYPE} ${KDL_SRCS} config.h)
+ 
+ SET_TARGET_PROPERTIES( orocos-kdl PROPERTIES
+-  SOVERSION "${KDL_VERSION_MAJOR}.${KDL_VERSION_MINOR}"
+-  VERSION "${KDL_VERSION}"
+   COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS}"
+   PUBLIC_HEADER "${KDL_HPPS};${CMAKE_CURRENT_BINARY_DIR}/config.h"
+   )


### PR DESCRIPTION
It seems that downstream libraries are now being linked to `liborocos_kdl.1.5.0.dylib` on macOS, that does not work well once 1.5.1 is released. With this fix (and rebuilding downstream libraries) only `liborocos_kdl.dylib` will be present and linked.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
